### PR TITLE
Possible alternative: Read from file to item

### DIFF
--- a/Project.vcxproj
+++ b/Project.vcxproj
@@ -38,29 +38,14 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 
-  <!-- Okay here's the relevant part -->
-
-  <!-- Step 1: Load SharedFiles.txt in as a string -->
-  <PropertyGroup>
-    <CmakeSharedFilenames_raw>$([System.IO.File]::ReadAllText('$(ProjectDir)SharedFiles.txt').TrimStart().TrimEnd())</CmakeSharedFilenames_raw>
-  </PropertyGroup>
-
-  <!-- Step 2 (optional): Perform a path transformation on each item, in this case prepending src/ -->
-  <PropertyGroup>
-    <CmakeSharedFilenames_raw_pathfix>$([System.Text.RegularExpressions.Regex]::Replace("$(CmakeSharedFilenames_raw)", "^", "src\", "System.Text.RegularExpressions.RegexOptions.Multiline"))</CmakeSharedFilenames_raw_pathfix>
-  </PropertyGroup>
-
-  <!-- Step 3: Convert from a string to a list -->
-  <!-- If you skip step 2, change CmakeSharedFilenames_raw_pathfix here to CmakeSharedFilenames_raw -->
-  <PropertyGroup>
-    <CmakeSharedFilenames>$([System.Text.RegularExpressions.Regex]::Split("$(CmakeSharedFilenames_raw_pathfix)", "\r?\n", "System.Text.RegularExpressions.RegexOptions.Singleline"))</CmakeSharedFilenames>
-  </PropertyGroup>
-
-  <!-- Step 4: Compile the list -->
   <ItemGroup>
+    <!-- Okay here's the relevant part -->
+
     <!-- Shared files -->
-    <!-- To add files to this list, edit SharedFiles.txt -->
-    <ClCompile Include="$(CmakeSharedFilenames)" />
+    <CmakeSharedFilenames Include="$([System.IO.File]::ReadAllText('$(ProjectDir)SharedFiles.txt').Trim().Split($([System.Environment]::NewLine), StringSplitOptions.RemoveEmptyEntries))" />
+
+    <!-- To add files to the shared list, edit SharedFiles.txt -->
+    <ClCompile Include="@(CmakeSharedFilenames->'src\%(Filename)%(Extension)')" />
 
     <!-- MSVC unique files -->
     <ClCompile Include="src/msvc-only.cpp" />

--- a/README.md
+++ b/README.md
@@ -26,6 +26,5 @@ The contents of this directory were created by Andi McClure for Love Conquers Al
 
 Things I wonder but do not care enough to find out:
 
-* Could the three "steps" in Project.vcxproj be collapsed into one? Would that make the MSBuild code look cleaner?
 * Could one publish some sort of MSBuild "library" so that you could just collapse the vcxproj "steps" into a function, and then just write `<ClCompile Include="$([FileInclude]::List('SharedFiles.txt', 'src/''))" />` or something?
 


### PR DESCRIPTION
This is a bit more concise and avoids some of the more complex regex-as-property-function approaches:

1. Condense the ReadAllText and manipulation operations into a single chained invocation.
2. Do that inside an item `Include` to create an item for each of the files in the text list.
3. Do the transformation to prepend `src\` at the item level instead of the textual level.